### PR TITLE
#17:

### DIFF
--- a/src/TestData/Building/Dynamic/DynamicBuilderExtensions.cs
+++ b/src/TestData/Building/Dynamic/DynamicBuilderExtensions.cs
@@ -67,7 +67,7 @@ namespace TestData.Building.Dynamic
             return builder;
         }
 
-        public static IDynamicBuilder<T> WithDependentValue<T, TProperty>(this IDynamicBuilder<T> builder, Expression<Func<T, TProperty>> property, Func<IDynamicBuilder<T>, TProperty> getValue)
+        public static IDynamicBuilder<T> WithBuilderDependentValue<T, TProperty>(this IDynamicBuilder<T> builder, Expression<Func<T, TProperty>> property, Func<IDynamicBuilder<T>, TProperty> getValue)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
             if (property == null) throw new ArgumentNullException(nameof(property));
@@ -78,6 +78,12 @@ namespace TestData.Building.Dynamic
             string name = ((MemberExpression)property.Body).Member.Name;
             builder.Overwrite(name, getValue(builder));
             return builder;
+        }
+
+        public static IDynamicBuilder<T> WithDependentValue<T, TProperty>(this IDynamicBuilder<T> builder, Expression<Func<T, TProperty>> property, Func<T, TProperty> getValue)
+        {
+            if (getValue == null) throw new ArgumentNullException(nameof(getValue));
+            return WithBuilderDependentValue(builder, property, b => getValue(b.Build()));
         }
 
         public static TProperty GetOverwrittenValue<T, TProperty>(this IDynamicBuilder<T> builder, Expression<Func<T, TProperty>> property)

--- a/src/TestData/Properties/AssemblyInfo.cs
+++ b/src/TestData/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyVersion("0.7.0.0")]
 [assembly: AssemblyFileVersion("0.7.0.0")]
-[assembly: AssemblyInformationalVersion("0.7.0-alpha.5+Branch.develop.Sha.b1a4a0af52e0e48aa5006b2ccbc645d3cfbb3926")]
+[assembly: AssemblyInformationalVersion("0.7.0-alpha.13+Branch.develop.Sha.3ddf88ff1ba7854f9dd1eb421e61392cd422d2b7")]


### PR DESCRIPTION
- Changed WithDependentValue extension method to use built object instead of builder;
- Implemented WithBuilderDependentValue extension method as the one using builder to get value;